### PR TITLE
feat: add Firebase auth and user management

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@prisma/client": "^6.14.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "firebase-admin": "^12.0.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "swagger-ui-express": "^5.0.1"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,3 +13,40 @@ datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
 }
+
+enum UserRole {
+  ADMIN
+  ADVOGADO
+  ESTAGIARIO
+  FINANCEIRO
+  CLIENTE
+}
+
+enum AccountStatus {
+  ACTIVE
+  SUSPENDED
+  DELETED
+}
+
+model User {
+  id               String        @id @default(uuid())
+  firebaseUid      String        @unique
+  fullName         String
+  email            String        @unique
+  phone            String?
+  cpf              String?       @unique
+  oab              String?       @unique
+  profilePhoto     String?
+  mfaEnabled       Boolean       @default(false)
+  lastLogin        DateTime?
+  failedAttempts   Int           @default(0)
+  accountStatus    AccountStatus @default(ACTIVE)
+  role             UserRole      @default(CLIENTE)
+  department       String?
+  unit             String?
+  supervisorId     String?
+  supervisor       User?         @relation("UserSupervisor", fields: [supervisorId], references: [id])
+  consentLgpd      Boolean       @default(false)
+  createdAt        DateTime      @default(now())
+  updatedAt        DateTime      @updatedAt
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,14 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { FirebaseModule } from './firebase/firebase.module';
+import { UsersModule } from './users/users.module';
+import { AuthModule } from './auth/auth.module';
 
 @Module({
-  imports: [],
+  imports: [ConfigModule.forRoot({ isGlobal: true }), FirebaseModule, UsersModule, AuthModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,38 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+
+import { AuthService } from './auth.service';
+import { RegisterEmailDto } from './dto/register-email.dto';
+import { RegisterMicrosoftDto } from './dto/register-microsoft.dto';
+import { LoginDto } from './dto/login.dto';
+import { UserEntity } from '../users/entities/user.entity';
+
+@ApiTags('auth')
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('register/email')
+  @ApiOperation({ summary: 'Cadastro via email e senha' })
+  async registerEmail(@Body() dto: RegisterEmailDto): Promise<UserEntity> {
+    return this.authService.registerWithEmail(dto);
+  }
+
+  @Post('register/microsoft')
+  @ApiOperation({ summary: 'Cadastro via Microsoft' })
+  async registerMicrosoft(@Body() dto: RegisterMicrosoftDto): Promise<UserEntity> {
+    return this.authService.registerWithMicrosoft(dto);
+  }
+
+  @Post('login/microsoft')
+  @ApiOperation({ summary: 'Login com Microsoft' })
+  async loginMicrosoft(@Body() dto: LoginDto): Promise<UserEntity> {
+    return this.authService.loginWithMicrosoft(dto);
+  }
+
+  @Post('login/email')
+  @ApiOperation({ summary: 'Login com email e senha' })
+  async loginEmail(@Body() dto: LoginDto): Promise<UserEntity> {
+    return this.authService.loginWithEmail(dto);
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+import { FirebaseModule } from '../firebase/firebase.module';
+import { UsersModule } from '../users/users.module';
+
+@Module({
+  imports: [FirebaseModule, UsersModule],
+  controllers: [AuthController],
+  providers: [AuthService],
+})
+export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { User } from '@prisma/client';
+
+import { FirebaseService } from '../firebase/firebase.service';
+import { UsersService } from '../users/users.service';
+import { RegisterEmailDto } from './dto/register-email.dto';
+import { RegisterMicrosoftDto } from './dto/register-microsoft.dto';
+import { LoginDto } from './dto/login.dto';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    private readonly firebaseService: FirebaseService,
+    private readonly usersService: UsersService,
+  ) {}
+
+  async registerWithEmail(dto: RegisterEmailDto): Promise<User> {
+    const record = await this.firebaseService.createUser(dto.email, dto.password, dto.fullName);
+    return this.usersService.create(record.uid, dto);
+  }
+
+  async registerWithMicrosoft(dto: RegisterMicrosoftDto): Promise<User> {
+    const decoded = await this.firebaseService.verifyIdToken(dto.idToken);
+    return this.usersService.create(decoded.uid, dto);
+  }
+
+  private async validateToken(idToken: string): Promise<User> {
+    const decoded = await this.firebaseService.verifyIdToken(idToken);
+    const user = await this.usersService.findByFirebaseUid(decoded.uid);
+    if (!user) {
+      throw new UnauthorizedException('Usuário não registrado');
+    }
+    await this.usersService.updateLoginInfo(user.id);
+    return user;
+  }
+
+  async loginWithMicrosoft(dto: LoginDto): Promise<User> {
+    return this.validateToken(dto.idToken);
+  }
+
+  async loginWithEmail(dto: LoginDto): Promise<User> {
+    return this.validateToken(dto.idToken);
+  }
+}

--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class LoginDto {
+  @ApiProperty()
+  @IsString()
+  idToken: string;
+}

--- a/src/auth/dto/register-email.dto.ts
+++ b/src/auth/dto/register-email.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+import { CreateUserDto } from '../../users/dto/create-user.dto';
+
+export class RegisterEmailDto extends CreateUserDto {
+  @ApiProperty()
+  @IsString()
+  password: string;
+}

--- a/src/auth/dto/register-microsoft.dto.ts
+++ b/src/auth/dto/register-microsoft.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+import { CreateUserDto } from '../../users/dto/create-user.dto';
+
+export class RegisterMicrosoftDto extends CreateUserDto {
+  @ApiProperty()
+  @IsString()
+  idToken: string;
+}

--- a/src/firebase/firebase.module.ts
+++ b/src/firebase/firebase.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+
+import { FirebaseService } from './firebase.service';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [FirebaseService],
+  exports: [FirebaseService],
+})
+export class FirebaseModule {}

--- a/src/firebase/firebase.service.ts
+++ b/src/firebase/firebase.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as admin from 'firebase-admin';
+
+@Injectable()
+export class FirebaseService {
+  private app: admin.app.App;
+
+  constructor(private readonly configService: ConfigService) {
+    const projectId = this.configService.get<string>('FIREBASE_PROJECT_ID');
+    const clientEmail = this.configService.get<string>('FIREBASE_CLIENT_EMAIL');
+    const privateKey = this.configService
+      .get<string>('FIREBASE_PRIVATE_KEY')
+      ?.replace(/\\n/g, '\n');
+
+    this.app = admin.initializeApp({
+      credential: admin.credential.cert({
+        projectId,
+        clientEmail,
+        privateKey,
+      }),
+    });
+  }
+
+  auth(): admin.auth.Auth {
+    return this.app.auth();
+  }
+
+  async createUser(email: string, password: string, displayName: string) {
+    return this.auth().createUser({ email, password, displayName });
+  }
+
+  async verifyIdToken(idToken: string) {
+    return this.auth().verifyIdToken(idToken);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,17 @@
+import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+
+  const config = new DocumentBuilder().setTitle('Luz API').setVersion('1.0').build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('docs', app, document);
+
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/src/prisma/prisma.module.ts
+++ b/src/prisma/prisma.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+
+import { PrismaService } from './prisma.service';
+
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {}

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -1,0 +1,13 @@
+import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async onModuleDestroy() {
+    await this.$disconnect();
+  }
+}

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,0 +1,58 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsEmail, IsEnum, IsOptional, IsString, IsUUID } from 'class-validator';
+import { UserRole } from '@prisma/client';
+
+export class CreateUserDto {
+  @ApiProperty()
+  @IsString()
+  fullName: string;
+
+  @ApiProperty()
+  @IsEmail()
+  email: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  phone?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  cpf?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  oab?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  profilePhoto?: string;
+
+  @ApiProperty({ enum: UserRole, default: UserRole.CLIENTE })
+  @IsOptional()
+  @IsEnum(UserRole)
+  role?: UserRole = UserRole.CLIENTE;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  department?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  unit?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsUUID()
+  supervisorId?: string;
+
+  @ApiProperty({ required: false, default: false })
+  @IsOptional()
+  @IsBoolean()
+  consentLgpd?: boolean = false;
+}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,0 +1,61 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { UserRole, AccountStatus } from '@prisma/client';
+
+export class UserEntity {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  firebaseUid: string;
+
+  @ApiProperty()
+  fullName: string;
+
+  @ApiProperty()
+  email: string;
+
+  @ApiProperty({ required: false })
+  phone?: string;
+
+  @ApiProperty({ required: false })
+  cpf?: string;
+
+  @ApiProperty({ required: false })
+  oab?: string;
+
+  @ApiProperty({ required: false })
+  profilePhoto?: string;
+
+  @ApiProperty({ default: false })
+  mfaEnabled: boolean;
+
+  @ApiProperty({ required: false })
+  lastLogin?: Date;
+
+  @ApiProperty({ default: 0 })
+  failedAttempts: number;
+
+  @ApiProperty({ enum: AccountStatus })
+  accountStatus: AccountStatus;
+
+  @ApiProperty({ enum: UserRole })
+  role: UserRole;
+
+  @ApiProperty({ required: false })
+  department?: string;
+
+  @ApiProperty({ required: false })
+  unit?: string;
+
+  @ApiProperty({ required: false })
+  supervisorId?: string;
+
+  @ApiProperty({ default: false })
+  consentLgpd: boolean;
+
+  @ApiProperty()
+  createdAt: Date;
+
+  @ApiProperty()
+  updatedAt: Date;
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+
+import { UsersService } from './users.service';
+import { UserEntity } from './entities/user.entity';
+
+@ApiTags('users')
+@Controller('users')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get(':firebaseUid')
+  @ApiOperation({ summary: 'Busca usuário pelo Firebase UID' })
+  @ApiParam({ name: 'firebaseUid', type: String })
+  async findByFirebaseUid(@Param('firebaseUid') firebaseUid: string): Promise<UserEntity | null> {
+    return this.usersService.findByFirebaseUid(firebaseUid);
+  }
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { UsersController } from './users.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [UsersController],
+  providers: [UsersService],
+  exports: [UsersService],
+})
+export class UsersModule {}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { User } from '@prisma/client';
+
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateUserDto } from './dto/create-user.dto';
+
+@Injectable()
+export class UsersService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(firebaseUid: string, data: CreateUserDto): Promise<User> {
+    return this.prisma.user.create({
+      data: {
+        firebaseUid,
+        ...data,
+      },
+    });
+  }
+
+  async findByFirebaseUid(firebaseUid: string): Promise<User | null> {
+    return this.prisma.user.findUnique({ where: { firebaseUid } });
+  }
+
+  async updateLoginInfo(id: string): Promise<User> {
+    return this.prisma.user.update({
+      where: { id },
+      data: { lastLogin: new Date(), failedAttempts: 0 },
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add Prisma user model with roles and security fields
- integrate Firebase admin and create auth endpoints for Microsoft and email flows
- configure Swagger and global validation

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8d63c214c832583c82bc5079fbbae