### PR TITLE
feat: list user contracts with file

### DIFF
--- a/src/contracts/contracts.controller.ts
+++ b/src/contracts/contracts.controller.ts
@@ -2,6 +2,7 @@
 import {
   Body,
   Controller,
+  Get,
   Param,
   ParseUUIDPipe,
   Patch,
@@ -18,6 +19,12 @@ import { LinkContractDto } from './dto/link-contract.dto';
 @Controller('api/v1/contracts')
 export class ContractsController {
   constructor(private readonly contractsService: ContractsService) {}
+
+  @Get('user/:userId')
+  @ApiOperation({ summary: 'Listar contratos do usuário' })
+  findAllByUser(@Param('userId', new ParseUUIDPipe()) userId: string) {
+    return this.contractsService.findAllByUser(userId);
+  }
 
   @Post()
   @ApiOperation({ summary: 'Vincular contrato publicado a cliente' })

--- a/src/contracts/contracts.service.ts
+++ b/src/contracts/contracts.service.ts
@@ -35,6 +35,16 @@ export class ContractsService {
     return this.transform(contract);
   }
 
+  async findAllByUser(userId: string): Promise<ContractEntity[]> {
+    const contracts = await this.prisma.client.contract.findMany({
+      where: { responsibleUsers: { some: { userId } } },
+      include: { file: true },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return contracts.map((contract) => this.transform(contract));
+  }
+
   async findOne(id: string): Promise<ContractEntity> {
     const contract = await this.prisma.client.contract.findUniqueOrThrow({
       where: { id },

--- a/src/contracts/entities/contract.entity.ts
+++ b/src/contracts/entities/contract.entity.ts
@@ -1,6 +1,8 @@
 // Entities
 import { ApiProperty } from '@nestjs/swagger';
 
+import { FileEntity } from '../../files/entities/file.entity';
+
 export class ContractEntity {
   @ApiProperty()
   id!: string;
@@ -13,6 +15,9 @@ export class ContractEntity {
 
   @ApiProperty({ required: false })
   fileId?: string;
+
+  @ApiProperty({ type: () => FileEntity, required: false })
+  file?: FileEntity;
 
   @ApiProperty()
   createdAt!: Date;


### PR DESCRIPTION
## Summary
- add endpoint to list contracts for a specific user
- support returning associated file data on contracts

## Testing
- `pnpm lint` (fails: Unsafe member access .supervisorId on an `any` value)
- `pnpm test` (fails: Cannot find module '../../generated/prisma' or its corresponding type declarations)
- `pnpm build` (fails: Cannot find module '../../../generated/prisma' or its corresponding type declarations)


------
https://chatgpt.com/codex/tasks/task_e_68ab8208debc8325a2990a03690b8eed