### PR TITLE
refactor: improve contract transform typing

### DIFF
--- a/src/contracts/contracts.service.ts
+++ b/src/contracts/contracts.service.ts
@@ -1,21 +1,29 @@
 // Services
 import { Injectable } from '@nestjs/common';
+import { Contract, File } from '@prisma/client';
+
 import { PrismaService } from '../prisma/prisma.service';
-import { ContractEntity } from './entities/contract.entity';
+import { FileEntity } from '../files/entities/file.entity';
 import { CreateContractDto } from './dto/create-contract.dto';
-import { UpdateContractDto } from './dto/update-contract.dto';
 import { LinkContractDto } from './dto/link-contract.dto';
+import { UpdateContractDto } from './dto/update-contract.dto';
+import { ContractEntity } from './entities/contract.entity';
 
 @Injectable()
 export class ContractsService {
   constructor(private readonly prisma: PrismaService) {}
 
-  private transform(contract: any): ContractEntity {
+  private transform(
+    contract: Contract & { file?: File | null },
+  ): ContractEntity {
     return {
       ...contract,
       clientId: contract.clientId ?? undefined,
       fileId: contract.fileId ?? undefined,
-    };
+      file: contract.file
+        ? (contract.file as unknown as FileEntity)
+        : undefined,
+    } as ContractEntity;
   }
 
   async create(dto: CreateContractDto): Promise<ContractEntity> {


### PR DESCRIPTION
## Summary
- type the contract transformer with Prisma Contract & File
- map optional file to FileEntity when present

## Testing
- `npm test` *(fails: Cannot find module '../../generated/prisma')*
- `npm run lint` *(fails: 167 errors, 3 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ab83223ab88325821069ebe5aaf056